### PR TITLE
launchpad.net/goyaml package has moved to github

### DIFF
--- a/bin/importer.go
+++ b/bin/importer.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"launchpad.net/goyaml"
 	"os"
 	"sort"
+
+	"github.com/go-yaml/yaml"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 		final[lang] = make(map[string][]string)
 
 		out := make(map[string]map[string]map[string]map[string]interface{})
-		err = goyaml.Unmarshal(in, out)
+		err = yaml.Unmarshal(in, out)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
hi @manveru, I use faker in one of my projects and have begun taking advantage of the [go vendor experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/edit), which recursively stores dependencies for your packages in the vendor directory.

Faker was causing an error because it depends on an outdated version of the yaml package. It used to be hosted on [launchpad](https://launchpad.net/goyaml), but moved to [github](https://github.com/go-yaml/yaml) in 2014. 

I've updated the imports.go file to reflect the new location for the dependency.

Thanks so much for this lib! We use it for making testing fun :)
