### PR TITLE
using correct import path for yaml

### DIFF
--- a/bin/importer.go
+++ b/bin/importer.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/go-yaml/yaml"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func main() {


### PR DESCRIPTION
the go yaml project has switched its repository to github, but the import path is using gopkg.in, updating for faker. Thanks to @AlekSi for the ht on this!