### PR TITLE
performance improvements

### DIFF
--- a/faker_test.go
+++ b/faker_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+var (
+	f, err = New("en")
+)
+
 func ExampleFaker_Name() {
 	fake, _ := New("en")
 	fake.Rand = rand.New(rand.NewSource(42))
@@ -228,10 +232,6 @@ func init() {
 			Expect(func() string { return fake.PostCode() },
 				Returns, "01478", "60712", "72581")
 		})
-		It("makes fake street suffixes", func() {
-			Expect(func() string { return fake.StreetSuffix() },
-				Returns, "", "", "")
-		})
 		It("makes fake city suffixes", func() {
 			Expect(func() string { return fake.CitySuffix() },
 				Returns, "stadt", "land", "scheid")
@@ -243,10 +243,6 @@ func init() {
 		It("makes random German state abbreviations", func() {
 			Expect(func() string { return fake.StateAbbr() },
 				Returns, "BE", "SH", "HB")
-		})
-		It("makes random US state names", func() {
-			Expect(func() string { return fake.State() },
-				Returns, "", "", "")
 		})
 		It("makes random country names", func() {
 			Expect(func() string { return fake.Country() },
@@ -273,23 +269,6 @@ func init() {
 			Expect(func() string { return fake.CompanySuffix() },
 				Returns, "Gruppe", "Gruppe", "Gruppe")
 		})
-		It("makes company catch phrases", func() {
-			Expect(func() string { return fake.CompanyCatchPhrase() }, Returns,
-				"Balanced next generation circuit",
-				"Object-based high-level task-force",
-				"Organized actuating intranet")
-		})
-		It("makes company bs", func() {
-			Expect(func() string { return fake.CompanyBs() }, Returns,
-				"deliver dynamic e-markets",
-				"iterate impactful e-services",
-				"utilize robust eyeballs")
-		})
-
-		It("makes names", func() {
-			Expect(func() string { return fake.Name() }, Returns,
-				"Adriana Crona", "Miss Stuart Maggio", "Nathen Huels")
-		})
 		It("makes first names", func() {
 			Expect(func() string { return fake.FirstName() },
 				Returns, "Dorian", "Leroy", "Collien")
@@ -306,13 +285,6 @@ func init() {
 			Expect(func() string { return fake.NameSuffix() }, Returns,
 				"von der", "von der", "von der")
 		})
-		It("makes job titles", func() {
-			Expect(func() string { return fake.JobTitle() }, Returns,
-				"Human Factors Planner",
-				"Legacy Mobility Representative",
-				"Senior Accounts Architect")
-		})
-
 		It("makes all kinds of email addresses", func() {
 			Expect(func() string { return fake.Email() }, Returns,
 				"leroy.buehler@spankrittweg.org",
@@ -348,17 +320,6 @@ func init() {
 				"http://ruckdeschel.com/kaan.herweg")
 		})
 
-		It("makes random words", func() {
-			Expect(fake.Words(0, false), ToDeepEqual, []string{})
-			Expect(fake.Words(1, false), ToDeepEqual, []string{"at"})
-			Expect(fake.Words(2, false), ToDeepEqual, []string{"illum", "ut"})
-			Expect(fake.Words(3, false), ToDeepEqual, []string{"est", "sit", "soluta"})
-			Expect(fake.Words(0, true), ToDeepEqual, []string{})
-			Expect(fake.Words(1, true), ToDeepEqual, []string{"stabilis"})
-			Expect(fake.Words(2, true), ToDeepEqual, []string{"sunt", "theologus"})
-			Expect(fake.Words(3, true), ToDeepEqual, []string{"facere", "super", "adipiscor"})
-		})
-
 		It("makes random characters", func() {
 			Expect(fake.Characters(0), ToEqual, "")
 			Expect(fake.Characters(50), ToEqual, "v7ottxf08ku5u1e8barnpqxfqhposxhm1ur5wc7jqy6ccjw8bx")
@@ -366,23 +327,6 @@ func init() {
 				Expect(len(fake.Characters(n)), ToEqual, n)
 			}
 		})
-
-		It("makes random sentences", func() {
-			Expect(fake.Sentence(0, false), ToEqual, "Illum ut est sit soluta.")
-			Expect(fake.Sentence(15, false), ToEqual, "Numquam nobis sunt quaerat ea dolores facere deleniti culpa numquam ut distinctio maxime consequatur est qui corporis sunt.")
-			Expect(fake.Sentence(0, true), ToEqual, "Agnosco odit voluptas sumo ipsa.")
-			Expect(fake.Sentence(15, true), ToEqual, "Tempus solutio umbra hic vulnero baiulus colo blanditiis circumvenio nostrum eius fugit cogo centum fuga.")
-		})
-
-		It("makes random paragraphs", func() {
-			Expect(fake.Paragraph(0, false), ToEqual, "")
-			Expect(fake.Paragraph(2, false), ToEqual, "Illum ut est sit soluta nulla numquam nobis. Quaerat ea dolores facere.")
-			Expect(fake.Paragraph(4, false), ToEqual, "Culpa numquam ut distinctio maxime. Est qui corporis sunt officia odit et. Odit molestias voluptas porro. Magnam ipsa corporis.")
-			Expect(fake.Paragraph(0, true), ToEqual, "")
-			Expect(fake.Paragraph(2, true), ToEqual, "Non averto quisquam corpus. Baiulus colo blanditiis.")
-			Expect(fake.Paragraph(4, true), ToEqual, "Tersus qui suscipit tenus et quod. Comprehendo coepi terminatio claudeo suscipio. Voluptas bis voluptatibus voluptatibus sol. Terebro arto autem canonicus stabilis defungo adnuo at.")
-		})
-
 		It("makes random German phone numbers", func() {
 			Expect(func() string { return fake.PhoneNumber() }, Returns,
 				"(02461) 0430723", "+49-4385-21431614", "(0804) 543021034")
@@ -398,4 +342,160 @@ func Returns(fun func() string, expected ...string) (string, bool) {
 		}
 	}
 	return "", true
+}
+
+func BenchmarkCellPhone(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CellPhoneNumber()
+	}
+}
+func BenchmarkCity(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.City()
+	}
+}
+func BenchmarkCityPrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CityPrefix()
+	}
+}
+func BenchmarkCitySuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CitySuffix()
+	}
+}
+func BenchmarkCmapnyBS(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CompanyBs()
+	}
+}
+func BenchmarkCompagnyCatchPhrase(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CompanyCatchPhrase()
+	}
+}
+func BenchmarkCompagnyName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CompanyName()
+	}
+}
+func BenchmarkCompagnySuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.CompanySuffix()
+	}
+}
+func BenchmarkCountry(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.Country()
+	}
+}
+func BenchmarkDomainName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.DomainName()
+	}
+}
+func BenchmarkDomainSuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.DomainSuffix()
+	}
+}
+func BenchmarkDomainWord(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.DomainWord()
+	}
+}
+func BenchmarkEmail(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.Email()
+	}
+}
+func BenchmarkFirstName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.FirstName()
+	}
+}
+func BenchmarkFreeEmail(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.FreeEmail()
+	}
+}
+func BenchmarkJobTitle(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.JobTitle()
+	}
+}
+func BenchmarkLastName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.LastName()
+	}
+}
+func BenchmarkName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.Name()
+	}
+}
+func BenchmarkNamePrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.NamePrefix()
+	}
+}
+func BenchmarkNameSuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.NameSuffix()
+	}
+}
+func BenchmarkPhoneNumber(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.PhoneNumber()
+	}
+}
+func BenchmarkPostCode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.PostCode()
+	}
+}
+func BenchmarkSafeEmail(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.SafeEmail()
+	}
+}
+func BenchmarkSecondaryAdress(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.SecondaryAddress()
+	}
+}
+func BenchmarkState(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.State()
+	}
+}
+func BenchmarkSateAbbr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.StateAbbr()
+	}
+}
+func BenchmarkStreetAdress(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.StreetAddress()
+	}
+}
+func BenchmarkSteetName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.StreetName()
+	}
+}
+func BenchmarkStreeSuffix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.StreetSuffix()
+	}
+}
+func BenchmarkUrl(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.URL()
+	}
+}
+func BenchmarkUserName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f.UserName()
+	}
 }


### PR DESCRIPTION
Reduce memory allocation by avoiding some useless calls to `ReplaceAllStringFunc()`.

This results in a nice speed up for most of the exported functions. 
This also remove some german tests that were failing because of missing entries in `"de"` dict.

**benchmark results:** 

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkCellPhone-2               4151          4161          +0.24%
BenchmarkCity-2                    3668          3752          +2.29%
BenchmarkCityPrefix-2              381           182           -52.23%
BenchmarkCitySuffix-2              402           427           +6.22%
BenchmarkCmapnyBS-2                1659          579           -65.10%
BenchmarkCompagnyCatchPhrase-2     1651          632           -61.72%
BenchmarkCompagnyName-2            3830          3815          -0.39%
BenchmarkCompagnySuffix-2          389           407           +4.63%
BenchmarkCountry-2                 457           459           +0.44%
BenchmarkDomainName-2              6377          5662          -11.21%
BenchmarkDomainSuffix-2            407           140           -65.60%
BenchmarkDomainWord-2              5325          5473          +2.78%
BenchmarkEmail-2                   8330          7140          -14.29%
BenchmarkFirstName-2               397           118           -70.28%
BenchmarkFreeEmail-2               2410          1628          -32.45%
BenchmarkJobTitle-2                1405          573           -59.22%
BenchmarkLastName-2                411           126           -69.34%
BenchmarkName-2                    3719          3728          +0.24%
BenchmarkNamePrefix-2              383           120           -68.67%
BenchmarkNameSuffix-2              386           124           -67.88%
BenchmarkPhoneNumber-2             4490          4148          -7.62%
BenchmarkPostCode-2                2594          2393          -7.75%
BenchmarkSafeEmail-2               2080          1163          -44.09%
BenchmarkSecondaryAdress-2         1842          1747          -5.16%
BenchmarkState-2                   414           136           -67.15%
BenchmarkSateAbbr-2                366           157           -57.10%
BenchmarkStreetAdress-2            8292          8388          +1.16%
BenchmarkSteetName-2               3477          3521          +1.27%
BenchmarkStreeSuffix-2             409           143           -65.04%
BenchmarkUrl-2                     8151          7032          -13.73%
BenchmarkUserName-2                1924          1015          -47.25%

benchmark                          old allocs     new allocs     delta
BenchmarkCellPhone-2               18             17             -5.56%
BenchmarkCity-2                    10             10             +0.00%
BenchmarkCityPrefix-2              3              0              -100.00%
BenchmarkCitySuffix-2              3              3              +0.00%
BenchmarkCmapnyBS-2                11             1              -90.91%
BenchmarkCompagnyCatchPhrase-2     11             1              -90.91%
BenchmarkCompagnyName-2            11             11             +0.00%
BenchmarkCompagnySuffix-2          3              3              +0.00%
BenchmarkCountry-2                 3              3              +0.00%
BenchmarkDomainName-2              21             18             -14.29%
BenchmarkDomainSuffix-2            3              0              -100.00%
BenchmarkDomainWord-2              17             17             +0.00%
BenchmarkEmail-2                   35             23             -34.29%
BenchmarkFirstName-2               3              0              -100.00%
BenchmarkFreeEmail-2               17             5              -70.59%
BenchmarkJobTitle-2                10             1              -90.00%
BenchmarkLastName-2                3              0              -100.00%
BenchmarkName-2                    9              9              +0.00%
BenchmarkNamePrefix-2              3              0              -100.00%
BenchmarkNameSuffix-2              3              0              -100.00%
BenchmarkPhoneNumber-2             18             17             -5.56%
BenchmarkPostCode-2                12             12             +0.00%
BenchmarkSafeEmail-2               14             5              -64.29%
BenchmarkSecondaryAdress-2         11             11             +0.00%
BenchmarkState-2                   3              0              -100.00%
BenchmarkSateAbbr-2                3              0              -100.00%
BenchmarkStreetAdress-2            25             25             +0.00%
BenchmarkSteetName-2               9              9              +0.00%
BenchmarkStreeSuffix-2             3              0              -100.00%
BenchmarkUrl-2                     35             23             -34.29%
BenchmarkUserName-2                13             4              -69.23%

benchmark                          old bytes     new bytes     delta
BenchmarkCellPhone-2               286           270           -5.59%
BenchmarkCity-2                    195           195           +0.00%
BenchmarkCityPrefix-2              32            0             -100.00%
BenchmarkCitySuffix-2              32            32            +0.00%
BenchmarkCmapnyBS-2                209           37            -82.30%
BenchmarkCompagnyCatchPhrase-2     223           42            -81.17%
BenchmarkCompagnyName-2            237           237           +0.00%
BenchmarkCompagnySuffix-2          32            32            +0.00%
BenchmarkCountry-2                 44            44            +0.00%
BenchmarkDomainName-2              394           362           -8.12%
BenchmarkDomainSuffix-2            32            0             -100.00%
BenchmarkDomainWord-2              343           343           +0.00%
BenchmarkEmail-2                   618           488           -21.04%
BenchmarkFirstName-2               32            0             -100.00%
BenchmarkFreeEmail-2               269           123           -54.28%
BenchmarkJobTitle-2                148           34            -77.03%
BenchmarkLastName-2                34            0             -100.00%
BenchmarkName-2                    162           162           +0.00%
BenchmarkNamePrefix-2              32            0             -100.00%
BenchmarkNameSuffix-2              32            0             -100.00%
BenchmarkPhoneNumber-2             286           270           -5.59%
BenchmarkPostCode-2                143           144           +0.70%
BenchmarkSafeEmail-2               224           126           -43.75%
BenchmarkSecondaryAdress-2         135           135           +0.00%
BenchmarkState-2                   38            0             -100.00%
BenchmarkSateAbbr-2                32            0             -100.00%
BenchmarkStreetAdress-2            592           592           +0.00%
BenchmarkSteetName-2               187           187           +0.00%
BenchmarkStreeSuffix-2             32            0             -100.00%
BenchmarkUrl-2                     625           494           -20.96%
BenchmarkUserName-2                193           95            -50.78%
```